### PR TITLE
Bump puppetlabs_spec_helper version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :development, :test do
   gem 'json'
-  gem 'puppetlabs_spec_helper', '~> 2.15.0'
+  gem 'puppetlabs_spec_helper', '~> 3.0.0'
   gem 'rake', '~> 13.0.0'
   gem 'rspec', '~> 3.9.0'
   gem 'rubocop', '~> 0.93.0', require: false


### PR DESCRIPTION
Hopefully it will fix

    No such file or directory @ dir_initialize - /home/runner/work/puppet-deprecate/puppet-deprecate/spec/fixtures/modules

Which i cannot replicate locally