### PR TITLE
Fix Rubocop RedundantRegexpArgument

### DIFF
--- a/lib/puppet/parser/functions/deprecate.rb
+++ b/lib/puppet/parser/functions/deprecate.rb
@@ -27,7 +27,7 @@ module Puppet::Parser::Functions
       raise ArgumentError, "deprecate(): wrong number of arguments (#{args.length} must be 2 or 3)"
     end
 
-    date             = args[0].gsub(/-/, '')
+    date             = args[0].gsub('-', '')
     reason           = args[1]
     fail_compilation = args[2] || false
 


### PR DESCRIPTION
[Correctable] Style/RedundantRegexpArgument: Use string "-" as argument instead of regexp /-/.